### PR TITLE
build: Add a docker-based build process

### DIFF
--- a/build/.gitignore
+++ b/build/.gitignore
@@ -1,0 +1,2 @@
+image*
+*.tar.gz

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,0 +1,27 @@
+from ubuntu:focal
+
+# tzdata fix: https://anonoz.github.io/tech/2020/04/24/docker-build-stuck-tzdata.html
+RUN apt update && \
+        DEBIAN_FRONTEND=noninteractive \
+        TZ=Asia/Singapore \
+        apt install -y openjdk-14-jdk p7zip-full ant git
+
+WORKDIR /Flashtool
+RUN git clone https://github.com/Androxyde/Flashtool .
+
+ARG revision
+
+RUN git checkout ${revision}
+
+# Follow BUILD.md now ..
+
+# We need to fetch and merge https://github.com/Androxyde/Flashtool/pull/141
+RUN git remote add fix https://github.com/derMart/Flashtool && git pull fix fix_build
+
+# The new BUILD.md:
+# https://github.com/derMart/Flashtool/blob/fix_build/BUILD.md
+
+RUN ant -buildfile ant/build-jar.xml
+RUN ant -buildfile ant/deploy-release.xml
+RUN ant -buildfile ant/setup-release.xml
+

--- a/build/Makefile
+++ b/build/Makefile
@@ -1,0 +1,14 @@
+tag := ubuntu:flashtool-builder
+revision := 56528c0795676d9f3362e288a11435bd2abe00bf # 0.9.28.0
+
+
+image: Dockerfile Makefile
+	docker build . --tag $(tag); \
+	touch $@;
+
+image-%: Dockerfile Makefile
+	docker build . --build-arg=revision=$* --tag $(addsuffix -$*, ${tag}); \
+	touch $@;
+
+flashtool-%-linux.tar.gz: image-%
+	docker run --rm -it $(addsuffix -$*, ${tag}) /bin/sh -c 'cat /Flashtool/Deploy/flashtool-*-linux.tar.gz' > $@

--- a/build/Makefile
+++ b/build/Makefile
@@ -11,4 +11,4 @@ image-%: Dockerfile Makefile
 	touch $@;
 
 flashtool-%-linux.tar.gz: image-%
-	docker run --rm -it $(addsuffix -$*, ${tag}) /bin/sh -c 'cat /Flashtool/Deploy/flashtool-*-linux.tar.gz' > $@
+	docker run --rm $(addsuffix -$*, ${tag}) /bin/sh -c 'cat /Flashtool/Deploy/flashtool-*-linux.tar.gz' > $@


### PR DESCRIPTION
Just a rough Dockerfile and Makefile.

To build a particular version of the Linux flashtool.*tar.gz, set up
Docker and GNU make and run:

  cd build
  COMMIT=56528c0
  make flashtool-${COMMIT}-linux.tar.gz